### PR TITLE
Replace Vue.js tags with Vue in frontmatter

### DIFF
--- a/src/articles/adding-a-sitemap-using-nuxt-content.md
+++ b/src/articles/adding-a-sitemap-using-nuxt-content.md
@@ -3,7 +3,7 @@ title: Adding a Sitemap Using Nuxt Content
 description: Here is how to add a sitemap to your Nuxt project when using the content module.
 image: https://res.cloudinary.com/redfern-web/image/upload/v1599840408/redfern-dev/png/nuxt.png
 tags:
-  - vuejs
+  - vue
   - nuxt
 published: "2020-09-01"
 permalink: "adding-a-sitemap-using-nuxt-content"

--- a/src/articles/adding-pagination-nuxt-content-blog.md
+++ b/src/articles/adding-pagination-nuxt-content-blog.md
@@ -2,7 +2,7 @@
 title: Adding Pagination to a Nuxt Blog
 description: "As your blog grows it will more than likely become necessary to paginate the listing page of articles. This post explains one way this can be achieved."
 image: "https://res.cloudinary.com/redfern-web/image/upload/v1599840408/redfern-dev/png/nuxt.png"
-tags: ["vuejs", "nuxt"]
+tags: ["vue", "nuxt"]
 published: "2020-09-28"
 permalink: "adding-pagination-nuxt-content-blog"
 ---

--- a/src/articles/adding-social-media-seo-meta-data-using-nuxt-content.md
+++ b/src/articles/adding-social-media-seo-meta-data-using-nuxt-content.md
@@ -2,7 +2,7 @@
 title: Adding Social Media & SEO Meta Data Using Nuxt Content
 description: "Here is how to add social media and SEO meta data to your Nuxt project when using the content module."
 image: "https://res.cloudinary.com/redfern-web/image/upload/v1599840408/redfern-dev/png/nuxt.png"
-tags: ["vuejs", "nuxt"]
+tags: ["vue", "nuxt"]
 published: "2020-09-17"
 permalink: "adding-social-media-seo-meta-data-using-nuxt-content"
 ---

--- a/src/articles/adding-tailwind-to-a-vuejs-project.md
+++ b/src/articles/adding-tailwind-to-a-vuejs-project.md
@@ -2,7 +2,7 @@
 title: "Adding Tailwind To a VueJS Project"
 description: "Simple instructions for setting up Tailwind CSS in your VueJS projects."
 image: "https://res.cloudinary.com/redfern-web/image/upload/v1598516539/redfern-dev/png/tailwind.png"
-tags: ["vuejs", "tailwind"]
+tags: ["vue", "tailwind"]
 published: "2019-12-03"
 permalink: "adding-tailwind-to-a-vuejs-project"
 ---

--- a/src/articles/authenticate-users-using-firebase-and-vuejs.md
+++ b/src/articles/authenticate-users-using-firebase-and-vuejs.md
@@ -2,7 +2,7 @@
 title: "Authenticate Users Using Firebase & VueJS"
 description: "In this tutorial we will work through building a simple VueJS app. It will use Firebase for authentication and allow users to sign-up and sign-in."
 image: "https://res.cloudinary.com/redfern-web/image/upload/v1599158299/redfern-dev/png/firebase-vue.png"
-tags: ["vuejs", "firebase"]
+tags: ["vue", "firebase"]
 published: "2020-09-03"
 permalink: "authenticate-users-using-firebase-and-vuejs"
 ---

--- a/src/articles/authentication-laravel-sanctum-fortify-for-an-spa.md
+++ b/src/articles/authentication-laravel-sanctum-fortify-for-an-spa.md
@@ -2,7 +2,7 @@
 title: "Authentication Using Laravel Sanctum & Fortify for an SPA"
 description: "How to set up full authentication using Laravel Sanctum & Fortify in a Vue SPA. Laravel API article"
 image: "https://res.cloudinary.com/redfern-web/image/upload/v1598516539/redfern-dev/png/laravel-sanctum.png"
-tags: ["laravel", "vuejs"]
+tags: ["laravel", "vue"]
 published: "2020-12-28"
 permalink: "authentication-laravel-sanctum-fortify-for-an-spa"
 ---

--- a/src/articles/authentication-vue-spa-with-laravel-sanctum-fortify.md
+++ b/src/articles/authentication-vue-spa-with-laravel-sanctum-fortify.md
@@ -2,7 +2,7 @@
 title: "Authentication in a Vue SPA with Laravel Sanctum & Fortify"
 description: "How to set up full authentication using Laravel Sanctum & Fortify in a Vue SPA. Vue SPA Article"
 image: "https://res.cloudinary.com/redfern-web/image/upload/v1609319409/redfern-dev/png/laravel-vue.png"
-tags: ["laravel", "vuejs"]
+tags: ["laravel", "vue"]
 published: "2020-12-30"
 permalink: "authentication-vue-spa-with-laravel-sanctum-fortify"
 ---

--- a/src/articles/base-input-form-element-vuejs-3.md
+++ b/src/articles/base-input-form-element-vuejs-3.md
@@ -2,7 +2,7 @@
 title: "Create a Base Input Form Element Vue 3"
 description: "Let’s take a look at how `v-model` has changed in Vue 3 and build a reusable BaseInput text field."
 image: "https://res.cloudinary.com/redfern-web/image/upload/v1599905729/redfern-dev/png/vue.png"
-tags: ["vuejs"]
+tags: ["vue"]
 published: "2020-10-27"
 permalink: "base-input-form-element-vuejs-3"
 ---

--- a/src/articles/email-verification-firebase-vuejs.md
+++ b/src/articles/email-verification-firebase-vuejs.md
@@ -2,7 +2,7 @@
 title: "Email Verification Using Firebase & VueJS"
 description: "This tutorial walks through adding email verification to the simple VueJS Firebase app we have been building."
 image: "https://res.cloudinary.com/redfern-web/image/upload/v1599158299/redfern-dev/png/firebase-vue.png"
-tags: ["vuejs", "firebase"]
+tags: ["vue", "firebase"]
 published: "2020-09-08"
 permalink: "email-verification-firebase-vuejs"
 ---

--- a/src/articles/forgot-password-firebase-vuejs.md
+++ b/src/articles/forgot-password-firebase-vuejs.md
@@ -2,7 +2,7 @@
 title: "Forgot Password Using Firebase & VueJS"
 description: "This tutorial walks through adding a forgot password page to the simple VueJS Firebase app we have been building."
 image: "https://res.cloudinary.com/redfern-web/image/upload/v1599158299/redfern-dev/png/firebase-vue.png"
-tags: ["vuejs", "firebase"]
+tags: ["vue", "firebase"]
 published: "2020-09-11"
 permalink: "forgot-password-firebase-vuejs"
 ---

--- a/src/articles/manage-user-state-vuex-and-firebase.md
+++ b/src/articles/manage-user-state-vuex-and-firebase.md
@@ -2,7 +2,7 @@
 title: "How to Manage User State With Vuex and Firebase"
 description: "This tutorial walks through adding Vuex to a simple VueJS Firebase app. We use Vuex to manage the logged in user state and display protected content."
 image: "https://res.cloudinary.com/redfern-web/image/upload/v1599158299/redfern-dev/png/firebase-vue.png"
-tags: ["vuejs", "firebase"]
+tags: ["vue", "firebase"]
 published: "2020-09-03"
 permalink: "manage-user-state-vuex-and-firebase"
 ---

--- a/src/articles/radio-buttons-vuejs.md
+++ b/src/articles/radio-buttons-vuejs.md
@@ -2,7 +2,7 @@
 title: "Radio Buttons VueJS"
 description: "Here is a quick example how to add radio buttons on a form managed by VueJS."
 image: "https://res.cloudinary.com/redfern-web/image/upload/v1599905729/redfern-dev/png/vue.png"
-tags: ["vuejs"]
+tags: ["vue"]
 published: "2020-09-12"
 permalink: "radio-buttons-vuejs"
 ---

--- a/src/articles/using-getters-and-setters-vuex.md
+++ b/src/articles/using-getters-and-setters-vuex.md
@@ -2,7 +2,7 @@
 title: "Using Getters & Setters Vuex"
 description: "A short article on using the getter and setter pattern to update data held in a Vuex store."
 image: "https://res.cloudinary.com/redfern-web/image/upload/v1599905729/redfern-dev/png/vue.png"
-tags: ["vuejs"]
+tags: ["vue"]
 published: "2021-01-06"
 permalink: "using-getters-and-setters-vuex"
 ---

--- a/src/articles/vuejs-auth-using-laravel-sanctum.md
+++ b/src/articles/vuejs-auth-using-laravel-sanctum.md
@@ -2,7 +2,7 @@
 title: "VueJS Auth Using Laravel Sanctum"
 description: "How to set up basic authentication using Laravel Sanctum in a VueJs SPA."
 image: "https://res.cloudinary.com/redfern-web/image/upload/v1598516539/redfern-dev/png/laravel-sanctum.png"
-tags: ["laravel", "vuejs"]
+tags: ["laravel", "vue"]
 published: "2020-01-12"
 permalink: "vuejs-auth-using-laravel-sanctum"
 ---


### PR DESCRIPTION
Updated all article files to use the standardized 'vue' tag instead of 'vuejs' for consistency across the blog.