### PR TITLE
Remove images from front matter

### DIFF
--- a/src/articles/adding-tailwind-to-a-vuejs-project.md
+++ b/src/articles/adding-tailwind-to-a-vuejs-project.md
@@ -1,7 +1,6 @@
 ---
 title: "Adding Tailwind To a VueJS Project"
 description: "Simple instructions for setting up Tailwind CSS in your VueJS projects."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1598516539/redfern-dev/png/tailwind.png"
 tags: ["vue", "tailwind"]
 published: "2019-12-03"
 permalink: "adding-tailwind-to-a-vuejs-project"

--- a/src/articles/authenticate-users-using-firebase-and-vuejs.md
+++ b/src/articles/authenticate-users-using-firebase-and-vuejs.md
@@ -1,7 +1,6 @@
 ---
 title: "Authenticate Users Using Firebase & VueJS"
 description: "In this tutorial we will work through building a simple VueJS app. It will use Firebase for authentication and allow users to sign-up and sign-in."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599158299/redfern-dev/png/firebase-vue.png"
 tags: ["vue", "firebase"]
 published: "2020-09-03"
 permalink: "authenticate-users-using-firebase-and-vuejs"

--- a/src/articles/authentication-laravel-sanctum-fortify-for-an-spa.md
+++ b/src/articles/authentication-laravel-sanctum-fortify-for-an-spa.md
@@ -1,7 +1,6 @@
 ---
 title: "Authentication Using Laravel Sanctum & Fortify for an SPA"
 description: "How to set up full authentication using Laravel Sanctum & Fortify in a Vue SPA. Laravel API article"
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1598516539/redfern-dev/png/laravel-sanctum.png"
 tags: ["laravel", "vue"]
 published: "2020-12-28"
 permalink: "authentication-laravel-sanctum-fortify-for-an-spa"

--- a/src/articles/authentication-vue-spa-with-laravel-sanctum-fortify.md
+++ b/src/articles/authentication-vue-spa-with-laravel-sanctum-fortify.md
@@ -1,7 +1,6 @@
 ---
 title: "Authentication in a Vue SPA with Laravel Sanctum & Fortify"
 description: "How to set up full authentication using Laravel Sanctum & Fortify in a Vue SPA. Vue SPA Article"
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1609319409/redfern-dev/png/laravel-vue.png"
 tags: ["laravel", "vue"]
 published: "2020-12-30"
 permalink: "authentication-vue-spa-with-laravel-sanctum-fortify"

--- a/src/articles/base-input-form-element-vuejs-3.md
+++ b/src/articles/base-input-form-element-vuejs-3.md
@@ -1,7 +1,6 @@
 ---
 title: "Create a Base Input Form Element Vue 3"
-description: "Let’s take a look at how `v-model` has changed in Vue 3 and build a reusable BaseInput text field."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599905729/redfern-dev/png/vue.png"
+description: "Let's take a look at how `v-model` has changed in Vue 3 and build a reusable BaseInput text field."
 tags: ["vue"]
 published: "2020-10-27"
 permalink: "base-input-form-element-vuejs-3"

--- a/src/articles/basic-module-pattern-javascript.md
+++ b/src/articles/basic-module-pattern-javascript.md
@@ -1,7 +1,6 @@
 ---
 title: "Basic Module Pattern JavaScript"
 description: "Wrap your code in an immediately invoked function expression (IFFE). It runs immediately when you create it and has no name."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599832342/redfern-dev/png/js.png"
 tags: ["javascript"]
 published: "2016-04-10"
 permalink: "basic-module-pattern-javascript"

--- a/src/articles/email-verification-firebase-vuejs.md
+++ b/src/articles/email-verification-firebase-vuejs.md
@@ -1,7 +1,6 @@
 ---
 title: "Email Verification Using Firebase & VueJS"
 description: "This tutorial walks through adding email verification to the simple VueJS Firebase app we have been building."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599158299/redfern-dev/png/firebase-vue.png"
 tags: ["vue", "firebase"]
 published: "2020-09-08"
 permalink: "email-verification-firebase-vuejs"

--- a/src/articles/factory-function-to-create-an-object-in-javascript.md
+++ b/src/articles/factory-function-to-create-an-object-in-javascript.md
@@ -1,7 +1,6 @@
 ---
 title: "Factory Function To Create An Object In JavaScript"
 description: "Use a constructor function that returns an object. You can then create multiple people passing in the first and last name arguments the `createPerson` function."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599832342/redfern-dev/png/js.png"
 tags: ["javascript"]
 published: "2016-04-09"
 permalink: "factory-function-to-create-an-object-in-javascript"

--- a/src/articles/forgot-password-firebase-vuejs.md
+++ b/src/articles/forgot-password-firebase-vuejs.md
@@ -1,7 +1,6 @@
 ---
 title: "Forgot Password Using Firebase & VueJS"
 description: "This tutorial walks through adding a forgot password page to the simple VueJS Firebase app we have been building."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599158299/redfern-dev/png/firebase-vue.png"
 tags: ["vue", "firebase"]
 published: "2020-09-11"
 permalink: "forgot-password-firebase-vuejs"

--- a/src/articles/javascript-async-await.md
+++ b/src/articles/javascript-async-await.md
@@ -1,7 +1,6 @@
 ---
 title: "JavaScript Async Await"
-description: "Working with JavaScript Promises you have a couple of approaches to consider for interacting with the response. The Promise doesn’t give you the response in the exact format you can work with, let's dive in and explore things."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599832342/redfern-dev/png/js.png"
+description: "Working with JavaScript Promises you have a couple of approaches to consider for interacting with the response. The Promise doesn't give you the response in the exact format you can work with, let's dive in and explore things."
 tags: ["javascript"]
 published: "2020-08-21"
 permalink: "javascript-async-await"

--- a/src/articles/javascript-objects.md
+++ b/src/articles/javascript-objects.md
@@ -1,7 +1,6 @@
 ---
 title: "JavaScript Objects"
 description: "JavaScript objects are used everywhere. It's an important concept to understand right from the beginning."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599832342/redfern-dev/png/js.png"
 tags: ["javascript"]
 published: "2016-04-10"
 permalink: "javascript-objects"

--- a/src/articles/javascript-promises.md
+++ b/src/articles/javascript-promises.md
@@ -1,7 +1,6 @@
 ---
 title: "JavaScript Promises"
 description: "JavaScript Promises are used in most modern web applications where we need to do some work that takes some time to complete. A popular example of this is fetching data from an API, where the result is needed to be displayed in your app."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599832342/redfern-dev/png/js.png"
 tags: ["javascript"]
 published: "2020-08-16"
 permalink: "javascript-promises"

--- a/src/articles/javascript-typeof-number.md
+++ b/src/articles/javascript-typeof-number.md
@@ -1,7 +1,6 @@
 ---
 title: "JavaScript typeof Number"
 description: "Often you will need to check that you have a number before using it in your JavaScript, here's how."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599832342/redfern-dev/png/js.png"
 tags: ["javascript"]
 published: "2020-08-28"
 permalink: "javascript-typeof-number"

--- a/src/articles/lambda-expressions-vs-anonymous-functions.md
+++ b/src/articles/lambda-expressions-vs-anonymous-functions.md
@@ -1,7 +1,6 @@
 ---
 title: "Lambda Expressions vs Anonymous Functions"
 description: "When learning a functional programming style you will often come across the term Lambda Expressions or Lambda Functions. In simple terms they are just functions that can be used as data and therefore declared as a value. Let's explore a few examples."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599832342/redfern-dev/png/js.png"
 tags: ["javascript"]
 published: "2020-08-29"
 permalink: "lambda-expressions-vs-anonymous-functions"

--- a/src/articles/laravel-testing-using-github-actions-with-mysql.md
+++ b/src/articles/laravel-testing-using-github-actions-with-mysql.md
@@ -1,7 +1,6 @@
 ---
 title: "Laravel Testing Using GitHub Actions With MYSQL"
 description: "Using GitHub actions for automating your Laravel tests is fairly straight forward, given the starter workflow they provide."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1598553741/redfern-dev/png/github-actions.png"
 tags: ["laravel", "testing"]
 published: "2020-05-09"
 permalink: "laravel-testing-using-github-actions-with-mysql"

--- a/src/articles/laravel-valet-installing-phpredis-with-pecl-homebrew.md
+++ b/src/articles/laravel-valet-installing-phpredis-with-pecl-homebrew.md
@@ -1,7 +1,6 @@
 ---
 title: "Laravel Valet Installing PHPRedis with PECL/Homebrew"
 description: "This post was written 3/2/2020 and explains how I got Redis working using Laravel Valet."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1598516539/redfern-dev/png/valet.png"
 tags: ["laravel"]
 published: "2020-02-03"
 permalink: "laravel-valet-installing-phpredis-with-pecl-homebrew"

--- a/src/articles/manage-user-state-vuex-and-firebase.md
+++ b/src/articles/manage-user-state-vuex-and-firebase.md
@@ -1,7 +1,6 @@
 ---
 title: "How to Manage User State With Vuex and Firebase"
 description: "This tutorial walks through adding Vuex to a simple VueJS Firebase app. We use Vuex to manage the logged in user state and display protected content."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599158299/redfern-dev/png/firebase-vue.png"
 tags: ["vue", "firebase"]
 published: "2020-09-03"
 permalink: "manage-user-state-vuex-and-firebase"

--- a/src/articles/managing-redis-locally-for-laravel-projects.md
+++ b/src/articles/managing-redis-locally-for-laravel-projects.md
@@ -1,7 +1,6 @@
 ---
 title: "Managing Redis Locally For Laravel Projects"
 description: "I recently found a neat app for managing your local databases from the makers of TablePlus. Read a short review of it."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599832035/redfern-dev/png/laravel.png"
 tags: ["laravel"]
 published: "2020-05-20"
 permalink: "managing-redis-locally-for-laravel-projects"

--- a/src/articles/passing-arguments-in-javascript.md
+++ b/src/articles/passing-arguments-in-javascript.md
@@ -1,7 +1,6 @@
 ---
 title: "Passing Arguments in Javascript"
 description: "You can pass arguments into functions to be used within the function. These arguments can be any JavaScript data type including functions."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599832342/redfern-dev/png/js.png"
 tags: ["javascript"]
 published: "2016-04-10"
 permalink: "passing-arguments-in-javascript"

--- a/src/articles/radio-buttons-vuejs.md
+++ b/src/articles/radio-buttons-vuejs.md
@@ -1,7 +1,6 @@
 ---
 title: "Radio Buttons VueJS"
 description: "Here is a quick example how to add radio buttons on a form managed by VueJS."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599905729/redfern-dev/png/vue.png"
 tags: ["vue"]
 published: "2020-09-12"
 permalink: "radio-buttons-vuejs"

--- a/src/articles/react-create-element.md
+++ b/src/articles/react-create-element.md
@@ -1,7 +1,6 @@
 ---
 title: Learn About React createElement
 description: "Lets break down how React's createElement method works in it's simplest form."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1601969094/redfern-dev/png/react.png"
 tags: ["react"]
 published: "2020-10-03"
 permalink: "react-create-element"

--- a/src/articles/react-use-state-hook.md
+++ b/src/articles/react-use-state-hook.md
@@ -1,7 +1,6 @@
 ---
 title: Learn About React useState Hook
 description: "Lets break down how React's useState hook works in it's simplest form."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1601969094/redfern-dev/png/react.png"
 tags: ["react"]
 published: "2020-10-04"
 permalink: "react-use-state-hook"

--- a/src/articles/switching-to-laravel-sail.md
+++ b/src/articles/switching-to-laravel-sail.md
@@ -1,7 +1,6 @@
 ---
 title: "Switching to Laravel Sail"
 description: "A quick write up for using Laravel Sail, with a solution to the set-up errors you can run into."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1608589316/redfern-dev/png/docker.png"
 tags: ["laravel"]
 published: "2020-12-21"
 permalink: "switching-to-laravel-sail"

--- a/src/articles/understanding-closures-in-javascript.md
+++ b/src/articles/understanding-closures-in-javascript.md
@@ -1,7 +1,6 @@
 ---
 title: "Understanding Closures In JavaScript"
 description: "This example shows how you create a closure in JavaScript it uses an alert function that can be incremented and reused/passed around."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599832342/redfern-dev/png/js.png"
 tags: ["javascript"]
 published: "2016-03-29"
 permalink: "understanding-closures-in-javascript"

--- a/src/articles/update-a-user-profile-in-laravel.md
+++ b/src/articles/update-a-user-profile-in-laravel.md
@@ -1,7 +1,6 @@
 ---
 title: "Update A User Profile In Laravel"
 description: "If you need to update other fields along with a unique field then you need to tell the unique rule to ignore the user's ID."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599832035/redfern-dev/png/laravel.png"
 tags: ["laravel"]
 published: "2016-04-25"
 permalink: "update-a-user-profile-in-laravel"

--- a/src/articles/using-getters-and-setters-vuex.md
+++ b/src/articles/using-getters-and-setters-vuex.md
@@ -1,7 +1,6 @@
 ---
 title: "Using Getters & Setters Vuex"
 description: "A short article on using the getter and setter pattern to update data held in a Vuex store."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599905729/redfern-dev/png/vue.png"
 tags: ["vue"]
 published: "2021-01-06"
 permalink: "using-getters-and-setters-vuex"

--- a/src/articles/using-javascript-to-access-url-segments.md
+++ b/src/articles/using-javascript-to-access-url-segments.md
@@ -1,7 +1,6 @@
 ---
 title: "Using JavaScript To Access URL Segments"
 description: "Whilst working on a recent project, I wanted an accordion navigation to remain open depending on what the category segment in the url was displaying."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1599832342/redfern-dev/png/js.png"
 tags: ["javascript"]
 published: "2020-06-19"
 permalink: "using-javascript-to-access-url-segments"

--- a/src/articles/vuejs-auth-using-laravel-sanctum.md
+++ b/src/articles/vuejs-auth-using-laravel-sanctum.md
@@ -1,7 +1,6 @@
 ---
 title: "VueJS Auth Using Laravel Sanctum"
 description: "How to set up basic authentication using Laravel Sanctum in a VueJs SPA."
-image: "https://res.cloudinary.com/redfern-web/image/upload/v1598516539/redfern-dev/png/laravel-sanctum.png"
 tags: ["laravel", "vue"]
 published: "2020-01-12"
 permalink: "vuejs-auth-using-laravel-sanctum"


### PR DESCRIPTION
Cleaned up front matter by removing image field references from all 28 articles. This streamlines the metadata structure and removes external Cloudinary image dependencies from the article definitions.