### PR TITLE
Change permalink to link in article YAML

### DIFF
--- a/src/articles/01-what-are-svgs.md
+++ b/src/articles/01-what-are-svgs.md
@@ -3,7 +3,7 @@ title: "What Are SVGs?"
 description: "An introduction to Scalable Vector Graphics (SVGs) — learn what they are, why they're useful, and how to use them in your web projects."
 tags: ["svg"]
 pubDate: "2025-11-28T09:00:00.000Z"
-permalink: "01-what-are-svgs"
+link: "01-what-are-svgs"
 ---
 
 ## Lesson 01: What Are SVGs?

--- a/src/articles/02-basic-shapes.md
+++ b/src/articles/02-basic-shapes.md
@@ -3,7 +3,7 @@ title: "Basic SVG Shapes?"
 description: "Learn about the fundamental SVG shapes — rectangles, circles, ellipses, lines, and polygons. Master the building blocks of SVG graphics."
 tags: ["svg"]
 pubDate: "2025-11-28T09:00:00.000Z"
-permalink: "02-basic-shapes"
+link: "02-basic-shapes"
 ---
 
 ## Lesson 02: Basic Shapes

--- a/src/articles/03-coordinate-system.md
+++ b/src/articles/03-coordinate-system.md
@@ -3,7 +3,7 @@ title: "The SVG Coordinate System"
 description: "Master the SVG coordinate system — understand how positioning works, how the origin is placed, and how to precisely control element placement in your graphics."
 tags: ["svg"]
 pubDate: "2025-11-29T09:00:00.000Z"
-permalink: "03-coordinate-system"
+link: "03-coordinate-system"
 ---
 
 ## Lesson 03: The Coordinate System

--- a/src/articles/adding-a-sitemap-using-nuxt-content.md
+++ b/src/articles/adding-a-sitemap-using-nuxt-content.md
@@ -3,7 +3,7 @@ title: Adding a Sitemap Using Nuxt Content
 description: Here is how to add a sitemap to your Nuxt project when using the content module.
 tags: ["vue", "nuxt"]
 pubDate: "2020-09-01T09:00:00.000Z"
-permalink: "adding-a-sitemap-using-nuxt-content"
+link: "adding-a-sitemap-using-nuxt-content"
 ---
 
 ## Adding a Sitemap Using Nuxt Content

--- a/src/articles/adding-pagination-nuxt-content-blog.md
+++ b/src/articles/adding-pagination-nuxt-content-blog.md
@@ -3,7 +3,7 @@ title: Adding Pagination to a Nuxt Blog
 description: "As your blog grows it will more than likely become necessary to paginate the listing page of articles. This post explains one way this can be achieved."
 tags: ["vue", "nuxt"]
 pubDate: "2020-09-28T09:00:00.000Z"
-permalink: "adding-pagination-nuxt-content-blog"
+link: "adding-pagination-nuxt-content-blog"
 ---
 
 ## Adding Pagination With Nuxt Content

--- a/src/articles/adding-social-media-seo-meta-data-using-nuxt-content.md
+++ b/src/articles/adding-social-media-seo-meta-data-using-nuxt-content.md
@@ -3,7 +3,7 @@ title: Adding Social Media & SEO Meta Data Using Nuxt Content
 description: "Here is how to add social media and SEO meta data to your Nuxt project when using the content module."
 tags: ["vue", "nuxt"]
 pubDate: "2020-09-17T09:00:00.000Z"
-permalink: "adding-social-media-seo-meta-data-using-nuxt-content"
+link: "adding-social-media-seo-meta-data-using-nuxt-content"
 ---
 
 ## Adding Social Media & SEO Meta Data Using Nuxt Content

--- a/src/articles/adding-tailwind-to-a-vuejs-project.md
+++ b/src/articles/adding-tailwind-to-a-vuejs-project.md
@@ -3,7 +3,7 @@ title: "Adding Tailwind To a VueJS Project"
 description: "Simple instructions for setting up Tailwind CSS in your VueJS projects."
 tags: ["vue", "tailwind"]
 pubDate: "2019-12-03T09:00:00.000Z"
-permalink: "adding-tailwind-to-a-vuejs-project"
+link: "adding-tailwind-to-a-vuejs-project"
 ---
 
 ## Adding Tailwind To a VueJS Project

--- a/src/articles/authenticate-users-using-firebase-and-vuejs.md
+++ b/src/articles/authenticate-users-using-firebase-and-vuejs.md
@@ -3,7 +3,7 @@ title: "Authenticate Users Using Firebase & VueJS"
 description: "In this tutorial we will work through building a simple VueJS app. It will use Firebase for authentication and allow users to sign-up and sign-in."
 tags: ["vue", "firebase"]
 pubDate: "2020-09-03T09:00:00.000Z"
-permalink: "authenticate-users-using-firebase-and-vuejs"
+link: "authenticate-users-using-firebase-and-vuejs"
 ---
 
 ## Authenticate Users Using Firebase & VueJS

--- a/src/articles/authentication-laravel-sanctum-fortify-for-an-spa.md
+++ b/src/articles/authentication-laravel-sanctum-fortify-for-an-spa.md
@@ -3,7 +3,7 @@ title: "Authentication Using Laravel Sanctum & Fortify for an SPA"
 description: "How to set up full authentication using Laravel Sanctum & Fortify in a Vue SPA. Laravel API article"
 tags: ["laravel", "vue"]
 pubDate: "2020-12-28T09:00:00.000Z"
-permalink: "authentication-laravel-sanctum-fortify-for-an-spa"
+link: "authentication-laravel-sanctum-fortify-for-an-spa"
 ---
 
 ## Authentication Using Laravel Sanctum & Fortify for an SPA

--- a/src/articles/authentication-vue-spa-with-laravel-sanctum-fortify.md
+++ b/src/articles/authentication-vue-spa-with-laravel-sanctum-fortify.md
@@ -3,7 +3,7 @@ title: "Authentication in a Vue SPA with Laravel Sanctum & Fortify"
 description: "How to set up full authentication using Laravel Sanctum & Fortify in a Vue SPA. Vue SPA Article"
 tags: ["laravel", "vue"]
 pubDate: "2020-12-30T09:00:00.000Z"
-permalink: "authentication-vue-spa-with-laravel-sanctum-fortify"
+link: "authentication-vue-spa-with-laravel-sanctum-fortify"
 ---
 
 ## Authentication in a Vue SPA with Laravel Sanctum & Fortify

--- a/src/articles/base-input-form-element-vuejs-3.md
+++ b/src/articles/base-input-form-element-vuejs-3.md
@@ -3,7 +3,7 @@ title: "Create a Base Input Form Element Vue 3"
 description: "Let's take a look at how `v-model` has changed in Vue 3 and build a reusable BaseInput text field."
 tags: ["vue"]
 pubDate: "2020-10-27T09:00:00.000Z"
-permalink: "base-input-form-element-vuejs-3"
+link: "base-input-form-element-vuejs-3"
 ---
 
 ## Create a Base Input Form Element Vue 3

--- a/src/articles/basic-module-pattern-javascript.md
+++ b/src/articles/basic-module-pattern-javascript.md
@@ -3,7 +3,7 @@ title: "Basic Module Pattern JavaScript"
 description: "Wrap your code in an immediately invoked function expression (IFFE). It runs immediately when you create it and has no name."
 tags: ["javascript"]
 pubDate: "2016-04-10T09:00:00.000Z"
-permalink: "basic-module-pattern-javascript"
+link: "basic-module-pattern-javascript"
 ---
 
 ## Basic Module Pattern JavaScript

--- a/src/articles/email-verification-firebase-vuejs.md
+++ b/src/articles/email-verification-firebase-vuejs.md
@@ -3,7 +3,7 @@ title: "Email Verification Using Firebase & VueJS"
 description: "This tutorial walks through adding email verification to the simple VueJS Firebase app we have been building."
 tags: ["vue", "firebase"]
 pubDate: "2020-09-08T09:00:00.000Z"
-permalink: "email-verification-firebase-vuejs"
+link: "email-verification-firebase-vuejs"
 ---
 
 ## Email Verification Using Firebase & VueJS

--- a/src/articles/factory-function-to-create-an-object-in-javascript.md
+++ b/src/articles/factory-function-to-create-an-object-in-javascript.md
@@ -3,7 +3,7 @@ title: "Factory Function To Create An Object In JavaScript"
 description: "Use a constructor function that returns an object. You can then create multiple people passing in the first and last name arguments the `createPerson` function."
 tags: ["javascript"]
 pubDate: "2016-04-09T09:00:00.000Z"
-permalink: "factory-function-to-create-an-object-in-javascript"
+link: "factory-function-to-create-an-object-in-javascript"
 ---
 
 ## Factory Function To Create An Object In JavaScript

--- a/src/articles/forgot-password-firebase-vuejs.md
+++ b/src/articles/forgot-password-firebase-vuejs.md
@@ -3,7 +3,7 @@ title: "Forgot Password Using Firebase & VueJS"
 description: "This tutorial walks through adding a forgot password page to the simple VueJS Firebase app we have been building."
 tags: ["vue", "firebase"]
 pubDate: "2020-09-11T09:00:00.000Z"
-permalink: "forgot-password-firebase-vuejs"
+link: "forgot-password-firebase-vuejs"
 ---
 
 ## Forgot Password Using Firebase & VueJS

--- a/src/articles/javascript-async-await.md
+++ b/src/articles/javascript-async-await.md
@@ -3,7 +3,7 @@ title: "JavaScript Async Await"
 description: "Working with JavaScript Promises you have a couple of approaches to consider for interacting with the response. The Promise doesn't give you the response in the exact format you can work with, let's dive in and explore things."
 tags: ["javascript"]
 pubDate: "2020-08-21T09:00:00.000Z"
-permalink: "javascript-async-await"
+link: "javascript-async-await"
 ---
 
 ## JavaScript Async Await

--- a/src/articles/javascript-objects.md
+++ b/src/articles/javascript-objects.md
@@ -3,7 +3,7 @@ title: "JavaScript Objects"
 description: "JavaScript objects are used everywhere. It's an important concept to understand right from the beginning."
 tags: ["javascript"]
 pubDate: "2016-04-10T09:00:00.000Z"
-permalink: "javascript-objects"
+link: "javascript-objects"
 ---
 
 ## JavaScript Objects

--- a/src/articles/javascript-promises.md
+++ b/src/articles/javascript-promises.md
@@ -3,7 +3,7 @@ title: "JavaScript Promises"
 description: "JavaScript Promises are used in most modern web applications where we need to do some work that takes some time to complete. A popular example of this is fetching data from an API, where the result is needed to be displayed in your app."
 tags: ["javascript"]
 pubDate: "2020-08-16T09:00:00.000Z"
-permalink: "javascript-promises"
+link: "javascript-promises"
 ---
 
 ## JavaScript Promises

--- a/src/articles/javascript-typeof-number.md
+++ b/src/articles/javascript-typeof-number.md
@@ -3,7 +3,7 @@ title: "JavaScript typeof Number"
 description: "Often you will need to check that you have a number before using it in your JavaScript, here's how."
 tags: ["javascript"]
 pubDate: "2020-08-28T09:00:00.000Z"
-permalink: "javascript-typeof-number"
+link: "javascript-typeof-number"
 ---
 
 ## JavaScript typeof Number

--- a/src/articles/lambda-expressions-vs-anonymous-functions.md
+++ b/src/articles/lambda-expressions-vs-anonymous-functions.md
@@ -3,7 +3,7 @@ title: "Lambda Expressions vs Anonymous Functions"
 description: "When learning a functional programming style you will often come across the term Lambda Expressions or Lambda Functions. In simple terms they are just functions that can be used as data and therefore declared as a value. Let's explore a few examples."
 tags: ["javascript"]
 pubDate: "2020-08-29T09:00:00.000Z"
-permalink: "lambda-expressions-vs-anonymous-functions"
+link: "lambda-expressions-vs-anonymous-functions"
 ---
 
 ## Lambda Expressions vs Anonymous Functions

--- a/src/articles/laravel-testing-using-github-actions-with-mysql.md
+++ b/src/articles/laravel-testing-using-github-actions-with-mysql.md
@@ -3,7 +3,7 @@ title: "Laravel Testing Using GitHub Actions With MYSQL"
 description: "Using GitHub actions for automating your Laravel tests is fairly straight forward, given the starter workflow they provide."
 tags: ["laravel", "testing"]
 pubDate: "2020-05-09T09:00:00.000Z"
-permalink: "laravel-testing-using-github-actions-with-mysql"
+link: "laravel-testing-using-github-actions-with-mysql"
 ---
 
 ## Laravel Testing Using GitHub Actions With MYSQL

--- a/src/articles/laravel-valet-installing-phpredis-with-pecl-homebrew.md
+++ b/src/articles/laravel-valet-installing-phpredis-with-pecl-homebrew.md
@@ -3,7 +3,7 @@ title: "Laravel Valet Installing PHPRedis with PECL/Homebrew"
 description: "This post was written 3/2/2020 and explains how I got Redis working using Laravel Valet."
 tags: ["laravel"]
 pubDate: "2020-02-03T09:00:00.000Z"
-permalink: "laravel-valet-installing-phpredis-with-pecl-homebrew"
+link: "laravel-valet-installing-phpredis-with-pecl-homebrew"
 ---
 
 ## Laravel Valet Installing PHPRedis with PECL/Homebrew

--- a/src/articles/manage-user-state-vuex-and-firebase.md
+++ b/src/articles/manage-user-state-vuex-and-firebase.md
@@ -3,7 +3,7 @@ title: "How to Manage User State With Vuex and Firebase"
 description: "This tutorial walks through adding Vuex to a simple VueJS Firebase app. We use Vuex to manage the logged in user state and display protected content."
 tags: ["vue", "firebase"]
 pubDate: "2020-09-03T09:00:00.000Z"
-permalink: "manage-user-state-vuex-and-firebase"
+link: "manage-user-state-vuex-and-firebase"
 ---
 
 ## How to Manage User State With Vuex and Firebase

--- a/src/articles/managing-redis-locally-for-laravel-projects.md
+++ b/src/articles/managing-redis-locally-for-laravel-projects.md
@@ -3,7 +3,7 @@ title: "Managing Redis Locally For Laravel Projects"
 description: "I recently found a neat app for managing your local databases from the makers of TablePlus. Read a short review of it."
 tags: ["laravel"]
 pubDate: "2020-05-20T09:00:00.000Z"
-permalink: "managing-redis-locally-for-laravel-projects"
+link: "managing-redis-locally-for-laravel-projects"
 ---
 
 ## Managing Redis Locally For Laravel Projects

--- a/src/articles/passing-arguments-in-javascript.md
+++ b/src/articles/passing-arguments-in-javascript.md
@@ -3,7 +3,7 @@ title: "Passing Arguments in Javascript"
 description: "You can pass arguments into functions to be used within the function. These arguments can be any JavaScript data type including functions."
 tags: ["javascript"]
 pubDate: "2016-04-10T09:00:00.000Z"
-permalink: "passing-arguments-in-javascript"
+link: "passing-arguments-in-javascript"
 ---
 
 ## Passing Arguments in Javascript

--- a/src/articles/radio-buttons-vuejs.md
+++ b/src/articles/radio-buttons-vuejs.md
@@ -3,7 +3,7 @@ title: "Radio Buttons VueJS"
 description: "Here is a quick example how to add radio buttons on a form managed by VueJS."
 tags: ["vue"]
 pubDate: "2020-09-12T09:00:00.000Z"
-permalink: "radio-buttons-vuejs"
+link: "radio-buttons-vuejs"
 ---
 
 ## Radio Buttons VueJS

--- a/src/articles/react-create-element.md
+++ b/src/articles/react-create-element.md
@@ -3,7 +3,7 @@ title: Learn About React createElement
 description: "Lets break down how React's createElement method works in it's simplest form."
 tags: ["react"]
 pubDate: "2020-10-03T09:00:00.000Z"
-permalink: "react-create-element"
+link: "react-create-element"
 ---
 
 ## React createElement

--- a/src/articles/react-use-state-hook.md
+++ b/src/articles/react-use-state-hook.md
@@ -3,7 +3,7 @@ title: Learn About React useState Hook
 description: "Lets break down how React's useState hook works in it's simplest form."
 tags: ["react"]
 pubDate: "2020-10-04T09:00:00.000Z"
-permalink: "react-use-state-hook"
+link: "react-use-state-hook"
 ---
 
 ## React useState Hook

--- a/src/articles/switching-to-laravel-sail.md
+++ b/src/articles/switching-to-laravel-sail.md
@@ -3,7 +3,7 @@ title: "Switching to Laravel Sail"
 description: "A quick write up for using Laravel Sail, with a solution to the set-up errors you can run into."
 tags: ["laravel"]
 pubDate: "2020-12-21T09:00:00.000Z"
-permalink: "switching-to-laravel-sail"
+link: "switching-to-laravel-sail"
 ---
 
 ## Switching to Laravel Sail

--- a/src/articles/understanding-closures-in-javascript.md
+++ b/src/articles/understanding-closures-in-javascript.md
@@ -3,7 +3,7 @@ title: "Understanding Closures In JavaScript"
 description: "This example shows how you create a closure in JavaScript it uses an alert function that can be incremented and reused/passed around."
 tags: ["javascript"]
 pubDate: "2016-03-29T09:00:00.000Z"
-permalink: "understanding-closures-in-javascript"
+link: "understanding-closures-in-javascript"
 ---
 
 ## Understanding Closures In JavaScript

--- a/src/articles/update-a-user-profile-in-laravel.md
+++ b/src/articles/update-a-user-profile-in-laravel.md
@@ -3,7 +3,7 @@ title: "Update A User Profile In Laravel"
 description: "If you need to update other fields along with a unique field then you need to tell the unique rule to ignore the user's ID."
 tags: ["laravel"]
 pubDate: "2016-04-25T09:00:00.000Z"
-permalink: "update-a-user-profile-in-laravel"
+link: "update-a-user-profile-in-laravel"
 ---
 
 ## Update A User Profile In Laravel

--- a/src/articles/using-getters-and-setters-vuex.md
+++ b/src/articles/using-getters-and-setters-vuex.md
@@ -3,7 +3,7 @@ title: "Using Getters & Setters Vuex"
 description: "A short article on using the getter and setter pattern to update data held in a Vuex store."
 tags: ["vue"]
 pubDate: "2021-01-06T09:00:00.000Z"
-permalink: "using-getters-and-setters-vuex"
+link: "using-getters-and-setters-vuex"
 ---
 
 ## Using Getters & Setters Vuex

--- a/src/articles/using-javascript-to-access-url-segments.md
+++ b/src/articles/using-javascript-to-access-url-segments.md
@@ -3,7 +3,7 @@ title: "Using JavaScript To Access URL Segments"
 description: "Whilst working on a recent project, I wanted an accordion navigation to remain open depending on what the category segment in the url was displaying."
 tags: ["javascript"]
 pubDate: "2020-06-19T09:00:00.000Z"
-permalink: "using-javascript-to-access-url-segments"
+link: "using-javascript-to-access-url-segments"
 ---
 
 ## Using JavaScript To Access URL Segments

--- a/src/articles/vue-to-svelte-forms.md
+++ b/src/articles/vue-to-svelte-forms.md
@@ -3,7 +3,7 @@ title: "Form Handling: Moving from Vue to Svelte"
 description: "A practical guide to translating Vue form patterns to Svelte, covering two-way binding, validation, async submission, and what actually works better in each framework."
 tags: ["vue", "svelte"]
 pubDate: "2025-11-28T09:00:00.000Z"
-permalink: "vue-to-svelte-forms"
+link: "vue-to-svelte-forms"
 ---
 
 ## Form Handling: Moving from Vue to Svelte

--- a/src/articles/vue-to-svelte-modal.md
+++ b/src/articles/vue-to-svelte-modal.md
@@ -3,7 +3,7 @@ title: "Building a Modal: Vue vs Svelte"
 description: "A side-by-side comparison of building a modal component in Vue 3 and Svelte 5, exploring the differences in reactivity, props, and component patterns."
 tags: ["vue", "svelte"]
 pubDate: "2025-11-27T09:00:00.000Z"
-permalink: "vue-to-svelte-modal"
+link: "vue-to-svelte-modal"
 ---
 
 ## Building a Modal: Vue vs Svelte

--- a/src/articles/vuejs-auth-using-laravel-sanctum.md
+++ b/src/articles/vuejs-auth-using-laravel-sanctum.md
@@ -3,7 +3,7 @@ title: "VueJS Auth Using Laravel Sanctum"
 description: "How to set up basic authentication using Laravel Sanctum in a VueJs SPA."
 tags: ["laravel", "vue"]
 pubDate: "2020-01-12T09:00:00.000Z"
-permalink: "vuejs-auth-using-laravel-sanctum"
+link: "vuejs-auth-using-laravel-sanctum"
 ---
 
 ## VueJS Auth Using Laravel Sanctum


### PR DESCRIPTION
Updated YAML frontmatter across all 36 articles to use 'link' instead of 'permalink' for consistency.